### PR TITLE
Handle SSR sanitizeHtml with fallback and tests

### DIFF
--- a/leopold-frontend/src/lib/utils/index.test.ts
+++ b/leopold-frontend/src/lib/utils/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'vitest';
+import { sanitizeHtml } from './index';
+
+describe('sanitizeHtml (SSR)', () => {
+  test('falls back to encoding without document', () => {
+    expect(typeof document).toBe('undefined');
+    const html = '<script>"&"</script>';
+    const sanitized = sanitizeHtml(html);
+    expect(sanitized).toBe('&lt;script&gt;&quot;&amp;&quot;&lt;/script&gt;');
+  });
+});

--- a/leopold-frontend/src/lib/utils/index.ts
+++ b/leopold-frontend/src/lib/utils/index.ts
@@ -790,9 +790,18 @@ export function validateUserRegistration(data: {
  * Sanitize HTML to prevent XSS
  */
 export function sanitizeHtml(html: string): string {
-  const div = document.createElement('div');
-  div.textContent = html;
-  return div.innerHTML;
+  if (typeof document !== 'undefined') {
+    const div = document.createElement('div');
+    div.textContent = html;
+    return div.innerHTML;
+  }
+
+  return html
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 /**


### PR DESCRIPTION
## Summary
- guard `sanitizeHtml` against missing `document`
- encode HTML entities when DOM APIs are unavailable
- cover SSR behavior with a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899a9b3133c832b90f07035d2ef468a