### PR TITLE
Respect explicit content types in API client

### DIFF
--- a/leopold-frontend/src/lib/api/client.test.ts
+++ b/leopold-frontend/src/lib/api/client.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+describe('APIClient header handling', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not set Content-Type for GET requests', async () => {
+    const { apiClient } = await import('./client');
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({})
+      } as Response);
+
+    await apiClient.getObservations();
+
+    expect(fetchMock).toHaveBeenCalled();
+    const [, options] = fetchMock.mock.calls[0];
+    const headers = (options?.headers ?? {}) as Record<string, string>;
+    const headerKeys = Object.keys(headers).map((h) => h.toLowerCase());
+    expect(headerKeys).not.toContain('content-type');
+  });
+
+  it('does not override headers for file uploads', async () => {
+    const { apiClient } = await import('./client');
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({})
+      } as Response);
+
+    const file = new File(['test'], 'test.txt', { type: 'text/plain' });
+    await apiClient.uploadImage(file);
+
+    const [, options] = fetchMock.mock.calls[0];
+    const headers = (options?.headers ?? {}) as Record<string, string>;
+    const headerKeys = Object.keys(headers).map((h) => h.toLowerCase());
+    expect(headerKeys).not.toContain('content-type');
+    expect(options?.body).toBeInstanceOf(FormData);
+  });
+});
+

--- a/leopold-frontend/src/lib/api/client.ts
+++ b/leopold-frontend/src/lib/api/client.ts
@@ -28,11 +28,22 @@ class APIClient {
   ): Promise<ApiResponse<T>> {
     const token = this.getAuthToken();
     
-    // Initialize headers properly
+    // Initialize headers and set defaults only when appropriate
     const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-      ...options.headers as Record<string, string>
+      ...(options.headers as Record<string, string>)
     };
+
+    const hasContentType = Object.keys(headers).some(
+      (key) => key.toLowerCase() === 'content-type'
+    );
+
+    if (
+      options.body &&
+      typeof options.body === 'string' &&
+      !hasContentType
+    ) {
+      headers['Content-Type'] = 'application/json';
+    }
 
     if (token) {
       headers.Authorization = `Bearer ${token}`;


### PR DESCRIPTION
## Summary
- Set `Content-Type: application/json` only when sending JSON bodies
- Allow callers to provide other content types without being overridden
- Test GET requests and file uploads for correct header behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899a9b422d8832b8cc84911feb4aafc