### PR TITLE
Handle zero-valued fields in validation

### DIFF
--- a/leopold-frontend/src/lib/utils/validation.test.ts
+++ b/leopold-frontend/src/lib/utils/validation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import { validateObservationForm, validateLocation } from './validation';
+
+// Tests for handling 0 values in validation utilities
+
+describe('validateObservationForm', () => {
+  test('accepts 0 coordinates', () => {
+    const result = validateObservationForm({
+      observation_type: 'visual',
+      species_name: 'Test',
+      location: { latitude: 0, longitude: 0 }
+    });
+
+    expect(result.errors.location).toBeUndefined();
+    expect(result.isValid).toBe(true);
+  });
+
+  test('errors when count is 0', () => {
+    const result = validateObservationForm({
+      observation_type: 'visual',
+      species_name: 'Test',
+      location: { latitude: 10, longitude: 10 },
+      count: 0
+    });
+
+    expect(result.errors.count).toBe('Count must be at least 1');
+  });
+
+  test('errors when confidence is 0', () => {
+    const result = validateObservationForm({
+      observation_type: 'visual',
+      species_name: 'Test',
+      location: { latitude: 10, longitude: 10 },
+      confidence: 0
+    });
+
+    expect(result.errors.confidence).toBe(
+      'Confidence must be between 1 and 5'
+    );
+  });
+});
+
+describe('validateLocation', () => {
+  test('accepts coordinates at 0', () => {
+    const result = validateLocation({ latitude: 0, longitude: 0 });
+
+    expect(result.errors.latitude).toBeUndefined();
+    expect(result.errors.longitude).toBeUndefined();
+    expect(result.isValid).toBe(true);
+  });
+});
+

--- a/leopold-frontend/src/lib/utils/validation.ts
+++ b/leopold-frontend/src/lib/utils/validation.ts
@@ -18,7 +18,15 @@ export function validateObservationForm(data: Partial<ObservationFormData>): Val
     errors.location = 'Location is required';
   } else {
     // Validate location
-    if (!data.location.latitude || !data.location.longitude) {
+    const { latitude, longitude } = data.location;
+    if (
+      latitude === undefined ||
+      latitude === null ||
+      isNaN(latitude) ||
+      longitude === undefined ||
+      longitude === null ||
+      isNaN(longitude)
+    ) {
       errors.location = 'Valid coordinates are required';
     }
   }
@@ -32,12 +40,21 @@ export function validateObservationForm(data: Partial<ObservationFormData>): Val
     warnings.notes = 'Notes are quite long. Consider shortening them.';
   }
 
-  if (data.count && data.count < 1) {
-    errors.count = 'Count must be at least 1';
+  if (data.count !== undefined) {
+    if (typeof data.count !== 'number' || isNaN(data.count) || data.count < 1) {
+      errors.count = 'Count must be at least 1';
+    }
   }
 
-  if (data.confidence && (data.confidence < 1 || data.confidence > 5)) {
-    errors.confidence = 'Confidence must be between 1 and 5';
+  if (data.confidence !== undefined) {
+    if (
+      typeof data.confidence !== 'number' ||
+      isNaN(data.confidence) ||
+      data.confidence < 1 ||
+      data.confidence > 5
+    ) {
+      errors.confidence = 'Confidence must be between 1 and 5';
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary
- ensure location latitude/longitude checks handle undefined and NaN values instead of relying on falsy checks
- validate provided count and confidence values and enforce their numeric ranges
- add tests for zero coordinates, count, and confidence

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6899b40abf10832bb1ca6447039841cd