### PR TITLE
Use reactive filters in ObservationMap

### DIFF
--- a/leopold-frontend/src/lib/components/ObservationMap.svelte
+++ b/leopold-frontend/src/lib/components/ObservationMap.svelte
@@ -41,8 +41,11 @@
   let isInitialized = false;
 
   // Filter state
-  let activeFilters = $filtersStore;
+  let activeFilters;
   let showFilterPanel = false;
+
+  // Keep active filters in sync with the store
+  $: activeFilters = $filtersStore;
   
   let layerControls: Record<ObservationType | 'verified', boolean> = {
     visual: true,


### PR DESCRIPTION
## Summary
- synchronize `activeFilters` with `filtersStore` using a Svelte reactive statement so map markers update when filters change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899b40921e4832bb2e6e103115d3116